### PR TITLE
Полноценное добавление ведущих ролей

### DIFF
--- a/Resources/Prototypes/_Lust/Maps/box.yml
+++ b/Resources/Prototypes/_Lust/Maps/box.yml
@@ -28,11 +28,13 @@
             ServiceWorker: [ 2, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
             TechnicalAssistant: [ 4, 4 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ]
             Chemist: [ 2, 3 ]
             MedicalDoctor: [ 4, 4 ]
             Paramedic: [ 1, 1 ]
@@ -40,12 +42,14 @@
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ]
             Scientist: [ 5, 5 ]
             ResearchAssistant: [ 4, 4 ]
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ]
             SecurityOfficer: [ 5, 5 ]
             Detective: [ 1, 1 ]
             SecurityCadet: [ 4, 4 ]

--- a/Resources/Prototypes/_Lust/Maps/delta.yml
+++ b/Resources/Prototypes/_Lust/Maps/delta.yml
@@ -60,7 +60,8 @@
             BlueShield: [ 1, 1 ]
             # security
             Brigmedic: [ 1, 1 ]
-             SeniorPhysician: [ 1, 1 ]
+            #senior
+            SeniorPhysician: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
-             SeniorEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ]

--- a/Resources/Prototypes/_Lust/Maps/delta.yml
+++ b/Resources/Prototypes/_Lust/Maps/delta.yml
@@ -60,3 +60,7 @@
             BlueShield: [ 1, 1 ]
             # security
             Brigmedic: [ 1, 1 ]
+             SeniorPhysician: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ]
+             SeniorEngineer: [ 1, 1 ]

--- a/Resources/Prototypes/_Lust/Maps/fland.yml
+++ b/Resources/Prototypes/_Lust/Maps/fland.yml
@@ -66,3 +66,8 @@
             IAA: [ 1, 1 ]
             Lawyer: [ 2, 2 ]
             Magistrat: [ 1, 1 ]
+            # senior
+            SeniorEngineer: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ]

--- a/Resources/Prototypes/_Lust/Maps/marathon.yml
+++ b/Resources/Prototypes/_Lust/Maps/marathon.yml
@@ -65,3 +65,8 @@
             IAA: [ 1, 1 ]
             Lawyer: [ 2, 2 ]
             Magistrat: [ 1, 1 ]
+            # senior
+            SeniorEngineer: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ]


### PR DESCRIPTION
## Проверки

- [ ] PR проверен на карте Delta.

**Changelog**
В прототипы карт Луста были добавлены ведущие роли, которые существовали и раньше, но не были прописаны в картах, из-за чего за них невозможно было зайти. Теперь эта проблема исправлена.