### PR TITLE
Гиперссылка в книге Корпозакона

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Books/hyperlinkbooks.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Books/hyperlinkbooks.yml
@@ -28,7 +28,7 @@
     - state: icon_law
       color: "#fff300"
   - type: HyperLink
-    url: https://sunrise14.top/wiki/%D0%9A%D0%BE%D1%80%D0%BF%D0%BE%D1%80%D0%B0%D1%82%D0%B8%D0%B2%D0%BD%D1%8B%D0%B9_%D0%97%D0%B0%D0%BA%D0%BE%D0%BD
+    url: https://sites.google.com/view/luststation-lore/%D0%BA%D0%BE%D1%80%D0%BF%D0%BE%D1%80%D0%B0%D1%82%D0%B8%D0%B2%D0%BD%D1%8B%D0%B9-%D0%B7%D0%B0%D0%BA%D0%BE%D0%BD # Lust Station КЗ
   - type: Tag
     tags:
     - Book


### PR DESCRIPTION
Заменена гиперссылка на КЗ Lust Station, вместо КЗ Sunrise.