### PR TITLE
Арканы теперь кушаются

### DIFF
--- a/Resources/Prototypes/_Lust/Entities/Mobs/Species/demon.yml
+++ b/Resources/Prototypes/_Lust/Entities/Mobs/Species/demon.yml
@@ -7,6 +7,7 @@
   components:
   - type: Interaction
     erp: true
+  - type: Absorbable
   - type: HumanoidAppearance
     species: Demon
   - type: Hunger


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Фикс несъедобности аркан для генокрадов
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Баг-фикс
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- Я не требую помощи для завершения PR
- Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
🆑 kanopus7
- fix: Генокрады теперь могут кушать аркан
