### PR TITLE
Рефактор сидения + фикс миспредикта сидения

### DIFF
--- a/Content.Server/_Lust/Rest/RestSystem.cs
+++ b/Content.Server/_Lust/Rest/RestSystem.cs
@@ -1,0 +1,57 @@
+﻿using Content.Shared._Lust.Rest;
+using Content.Shared.Interaction.Components;
+
+namespace Content.Server._Lust.Rest;
+
+public sealed class RestSystem : SharedRestSystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RestAbilityComponent, RestDoAfterEvent>(OnSuccess);
+    }
+
+    /// <summary>
+    /// Метод, вызываемый после успешного срабатывнаия дуафтера
+    /// </summary>
+    private void OnSuccess(EntityUid uid, RestAbilityComponent ability, RestDoAfterEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (args.Cancelled)
+            return;
+
+        // Переключаем маркер сидения
+        ability.IsResting = !ability.IsResting;
+        Dirty(uid, ability);
+
+        // Переключаем возможность ходить и запрашиваем смену спрайта
+        ToggleRestLogic(uid, ability.IsResting);
+        RaiseNetworkEvent(new RestChangeSpriteEvent{Entity = GetNetEntity(uid)});
+
+        args.Handled = true;
+    }
+
+    /// <summary>
+    /// Запрещает двигаться пока цель сидит
+    /// </summary>
+    /// <param name="uid">Цель</param>
+    /// <param name="isResting">Сидим ли мы</param>
+    private void ToggleRestLogic(EntityUid uid, bool isResting)
+    {
+        if (isResting)
+        {
+            var block = EnsureComp<BlockMovementComponent>(uid);
+
+            // Позволяет вертеться и делать всякие другие вещи, отличные от передвижения
+            block.BlockInteraction = false;
+            Dirty(uid, block);
+        }
+        else
+        {
+            RemComp<BlockMovementComponent>(uid);
+        }
+    }
+}

--- a/Content.Shared/_Lust/Rest/RestAbilityStuff.cs
+++ b/Content.Shared/_Lust/Rest/RestAbilityStuff.cs
@@ -5,22 +5,21 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared._Lust.Rest;
 
-[RegisterComponent, NetworkedComponent]
+/// <summary>
+/// Компонент, дающий возможность сидеть или вставать.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RestAbilityComponent : Component
 {
-    [DataField] public bool IsResting;
+    /// <summary>
+    /// Находимся ли мы в положении сидя?
+    /// </summary>
+    [DataField, AutoNetworkedField] public bool IsResting;
 
+    /// <summary>
+    /// КД дуафтера для начала сидения/вставания
+    /// </summary>
     [DataField] public TimeSpan Cooldown = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// Бекап скорости передвижения, так как она сбрасывается до нуля при сидении
-    /// </summary>
-    public float PreviousWalkSpeed;
-
-    /// <summary>
-    /// Бекап скорости передвижения, так как она сбрасывается до нуля при сидении
-    /// </summary>
-    public float PreviousSprintSpeed;
 
     /// <summary>
     /// Список слоев, которые будут выключаться вместе с основным спрайтом. В строках.
@@ -49,9 +48,10 @@ public sealed partial class RestActionEvent : InstantActionEvent {}
 [Serializable, NetSerializable]
 public sealed partial class RestDoAfterEvent : SimpleDoAfterEvent {}
 
+[Serializable, NetSerializable]
 public sealed partial class RestChangeSpriteEvent : EntityEventArgs
 {
-    public EntityUid Entity;
+    public NetEntity Entity;
 }
 
 public sealed partial class ActionLightToggledSunriseEvent : CancellableEntityEventArgs {}


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Каким-то образом с момента мержа боргов система успела сломаться и на второе использование акшена сидения клиент рассинронился с сервером из-за дуафтера. И это приводило к тому, что борг бегал на коленях, а сидел стоя.
Непонятно как и что случилось, но я это починил

**А еще я рефакторнул некоторые моменты:**
Сидение теперь не убирает скорость в 0, а использует для этого специальный компонент
Системы теперь разделены на абстрактную шаред, и 2 наследника на сервере и клиенте
Метод обрабатывающий убирание слоев теперь выглядит намного лучше и не заканчивается, если строковый список пуст, а енумовский нет.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

баги

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**

:cl:
- fix: Фикс неправильного предугадывания клиентом сидения борга после второй активации