### PR TITLE
Изменение количества слотов под мини-шприцы в авто-шприцемёте

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Launchers/syringe_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Launchers/syringe_guns.yml
@@ -13,7 +13,7 @@
     grid:
     - 0,0,2,0
   - type: Gun
-    fireRate: 0.8
+    fireRate: 0,8
   - type: Item
     size: Normal
     shape:
@@ -82,7 +82,7 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,4,1
+    - 0,0,4,0 #BALANCE PR
   - type: Gun
     fireRate: 1.8
     selectedMode: FullAuto


### PR DESCRIPTION
## Кратное описание
Изменить количество доступных слотов в авто-шприцемёте с 10 -> 5

## По какой причине
Коллективно решили (Я и ещё моих коллег-прототиперов) что 10 слотов под шприцы это сильно много, с учётом скорости стрельбы авто-шприцемёта. В целях НЕ изменения второго, было решено, как было сказано, изменить кол-во слотов в сторону баланса.

## Медиа(Видео/Скриншоты)
![request](https://github.com/user-attachments/assets/7f1f21bb-3015-46fc-8ecf-eb9830360800)


## Проверки

- [Х] Я не требую помощи для завершения PR
- [Х] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [Х] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**

SqerDust
Изменено: Изменено количество слотов под мини-шприцы в авто-шприцемёте с 10 до 5 штук.
