### PR TITLE
[Костыль] Спавн шаттлов ОБР и ПЦК, ибо Вигерсу важно чтобы это был геймрул, а не loadgrid

### DIFF
--- a/Resources/Locale/ru-RU/_lust/shuttlespawn.ftl
+++ b/Resources/Locale/ru-RU/_lust/shuttlespawn.ftl
@@ -1,0 +1,2 @@
+station-event-ertsquad-shuttle-incoming = Внимание! В ваш сектор был направлен отряд ДСО, сохраняйте спокойствие.
+station-event-centcomvisitor-shuttle-incoming = Внимание! В ваш сектор был направлен представитель центрального командования.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -598,3 +598,31 @@
       min: 1
       max: 1
       pickPlayer: false
+
+# Lust-start
+- type: entity
+  parent: BaseGameRule
+  id: ERTSquadShuttleSpawn
+  components:
+  - type: StationEvent
+    duration: null
+    startAnnouncement: station-event-ertsquad-shuttle-incoming
+    startAudio:
+      path: /Audio/_Sunrise/Announcements/sunrise_ert_accepted.ogg
+  - type: RuleGrids
+  - type: LoadMapRule
+    mapPath: /Maps/_Sunrise/Shuttles/mini_ERT_suc.yml
+
+- type: entity
+  parent: BaseGameRule
+  id: CentcomVisitorShuttleSpawn
+  components:
+  - type: StationEvent
+    duration: null
+    startAnnouncement: station-event-centcomvisitor-shuttle-incoming
+    startAudio:
+      path: /Audio/_Sunrise/Announcements/announce_dig.ogg
+  - type: RuleGrids
+  - type: LoadMapRule
+    mapPath: /Maps/_Sunrise/Shuttles/centcom_shuttle.yml
+# Lust-end


### PR DESCRIPTION
## Кратное описание
2 геймрула
ERTSquadShuttleSpawn - спавнит шаттл /Maps/_Sunrise/Shuttles/mini_ERT_suc.yml
CentcomVisitorShuttleSpawn - спавнит шаттл /Maps/_Sunrise/Shuttles/centcom_shuttle.yml

## По какой причине
Забрали возможность грузить шаттл через loadgrid, альтернатив не дали.

## Проверки

- [✓] Я не требую помощи для завершения PR
- [✓ ] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.