### PR TITLE
[FIX] Прикручиваем недостающие кнопки сервисному боргу

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -339,3 +339,10 @@
   # Pet
   petSuccessString: petting-success-service-cyborg
   petFailureString: petting-failure-service-cyborg
+  # Lust-start
+  addComponents:
+  - type: ActionGrant
+    actions:
+    - ActionViewLaws
+    - RestActionService
+  # Lust-end


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Прикручиваем недостающие кнопки сервисному боргу, а именно просмотр законов и возможность сесть.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Сервисный борг даже с существующими ресурсами и компонентами почему-то был лишен кнопок, которыми оснащены другие борги.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
На текущий момент кнопки выглядят так:
![no](https://github.com/user-attachments/assets/3f0e3a07-e2fd-4879-9435-812e09b9b961)

Данный PR привносит две кнопки, которые можно увидеть здесь:
![yes](https://github.com/user-attachments/assets/3acfbb57-0afe-4325-88f7-209dbace5663)

Проверка возможности посадить борга:
![yes-yes-yes](https://github.com/user-attachments/assets/9f3f48ef-8eb6-496c-a89e-150a76d09827)

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Ne0shka
- fix: Сервисный борг теперь имеет возможность просматривать законы и садиться.