### PR TITLE
[FIX] Возвращаем текстуру КПК горничной на место

### DIFF
--- a/Resources/Prototypes/_Lust/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Lust/Entities/Objects/Devices/pda.yml
@@ -4,6 +4,7 @@
   name: Command maid PDA
   components:
   - type: Sprite
+    sprite: _Lust/Objects/Devices/pda.rsi
   - type: Pda
     id: CommaidIDCard
   - type: Appearance
@@ -12,5 +13,4 @@
         !type:String
         pda-commaid
   - type: Icon
-    sprite: _Lust/Objects/Devices/pda.rsi
     state: pda-commaid


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Исправление ошибки текстуры КПК горничной командования

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
На текущий момент текстура не подгружается, т.к. свойство КПК указано неверно. Поэтому игроки видят "еррорку" вместо текстуры.

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
На текущий момент текстура выглядит так:
![error](https://github.com/user-attachments/assets/2728e6b2-c157-4888-8ece-5e5ffde831ea)

Данный PR фиксит текстуру, результат можно увидеть здесь:
![kpk](https://github.com/user-attachments/assets/b6ba8f24-3a35-4300-8d7e-77fb500ca2d7)


**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: Ne0shka
- fix: Исправлена текстура КПК горничной командования.