### PR TITLE
Удаление экстры из пулла Секрета

### DIFF
--- a/Resources/Prototypes/_Sunrise/secret_weights.yml
+++ b/Resources/Prototypes/_Sunrise/secret_weights.yml
@@ -14,13 +14,12 @@
 - type: weightedRandom
   id: LustSpectralSecret
   weights:
-    Extra: 0.50
-    Traitor: 0.15
-    BloodCult: 0.05
-    AssaultOps: 0.05
-    FleshCult: 0.05
-    Revolutionary: 0.05
-    Nukeops: 0.05
+    Traitor: 0.35
+    BloodCult: 0.10
+    AssaultOps: 0.10
+    FleshCult: 0.10
+    Revolutionary: 0.10
+    Nukeops: 0.10
     Wizard: 0.05
     Zombie: 0.05
     Survival: 0.05


### PR DESCRIPTION
[Предложка](https://github.com/space-sunrise/lust-station/issues/234) от [Феди](https://github.com/ifedya) 
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Изменены шансы выбора режима в секрете.
<!-- Что вы предлагаете изменить с помощью своего PR? -->

## По какой причине
Последнее время, на протяжении длительного времени чередуется режим "Мирный" с режимом "Секрет", непосредственно администрацией, шансы на "Экстру" настолько высоки, что какие-либо динамические режимы попросту не выбираются (Сжатый текст из ишуя от [Феди](https://github.com/ifedya))
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->