### PR TITLE
Замена НТ на QIllu --> fix 1.1

### DIFF
--- a/Tools/_lust/replace_nt.py
+++ b/Tools/_lust/replace_nt.py
@@ -8,7 +8,6 @@ REPLACEMENTS = {
     r"\bНТ\b": "Qillu",
     r"\bНанотрейзен\b": "Qillu",
     r"\bNanoTrasen\b": "Qillu",
-    r"\bНаноТрейзен\b": "Qillu",
 }
 
 def process_ftl_files(locale_dir: Path):
@@ -18,8 +17,15 @@ def process_ftl_files(locale_dir: Path):
 
     for file_path in locale_dir.rglob("*.ftl"):
         content = file_path.read_text(encoding="utf-8")
-        for pattern, replacement in REPLACEMENTS.items():
-            content = re.sub(pattern, replacement, content)
+        lines = []
+        for line in content.splitlines(True):
+            if "=" in line and not line.lstrip().startswith("#"):
+                left, right = line.split("=", 1)
+                for pattern, replacement in REPLACEMENTS.items():
+                    right = re.sub(pattern, replacement, right, flags=re.IGNORECASE)
+                line = left + "=" + right
+            lines.append(line)
+        content = "".join(lines)
         file_path.write_text(content, encoding="utf-8")
     print(f"Обработка завершена для {locale_dir}")
 

--- a/Tools/_lust/replace_nt.py
+++ b/Tools/_lust/replace_nt.py
@@ -10,6 +10,18 @@ REPLACEMENTS = {
     r"\bNanoTrasen\b": "Qillu",
 }
 
+PLACEHOLDER_SPLIT = re.compile(r'(\{[^{}]*\})')
+
+def replace_outside_placeholders(text: str) -> str:
+    parts = PLACEHOLDER_SPLIT.split(text)
+    for i, seg in enumerate(parts):
+        if seg.startswith('{') and seg.endswith('}'):
+            continue
+        for pattern, replacement in REPLACEMENTS.items():
+            seg = re.sub(pattern, replacement, seg, flags=re.IGNORECASE)
+        parts[i] = seg
+    return ''.join(parts)
+
 def process_ftl_files(locale_dir: Path):
     if not locale_dir.exists():
         print(f"Директория {locale_dir} не найдена, создаём её")
@@ -21,8 +33,7 @@ def process_ftl_files(locale_dir: Path):
         for line in content.splitlines(True):
             if "=" in line and not line.lstrip().startswith("#"):
                 left, right = line.split("=", 1)
-                for pattern, replacement in REPLACEMENTS.items():
-                    right = re.sub(pattern, replacement, right, flags=re.IGNORECASE)
+                right = replace_outside_placeholders(right)
                 line = left + "=" + right
             lines.append(line)
         content = "".join(lines)

--- a/Tools/_lust/replace_nt.py
+++ b/Tools/_lust/replace_nt.py
@@ -10,18 +10,38 @@ REPLACEMENTS = {
     r"\bНанотрейзен\b": "Qillu",
 }
 
-PLACEHOLDER_SPLIT = re.compile(r'(\{[^{}]*\})')
+REPLACEMENTS_CI = [(re.compile(p, re.IGNORECASE), r) for p, r in REPLACEMENTS.items()]
 ATTR_RE = re.compile(r'^\s*\.[-\w]+\s*=')
 
-def replace_outside_placeholders(text: str) -> str:
-    parts = PLACEHOLDER_SPLIT.split(text)
-    for i, seg in enumerate(parts):
-        if seg.startswith('{') and seg.endswith('}'):
-            continue
-        for pat, repl in REPLACEMENTS.items():
-            seg = re.sub(pat, repl, seg, flags=re.IGNORECASE)
-        parts[i] = seg
-    return ''.join(parts)
+def replace_outside_placeholders(text: str, depth: int = 0):
+    out, buf = [], []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '{':
+            if depth == 0 and buf:
+                seg = ''.join(buf)
+                for pat, repl in REPLACEMENTS_CI:
+                    seg = pat.sub(repl, seg)
+                out.append(seg)
+                buf = []
+            depth += 1
+            out.append(ch)
+        elif ch == '}' and depth > 0:
+            depth -= 1
+            out.append(ch)
+        else:
+            if depth == 0:
+                buf.append(ch)
+            else:
+                out.append(ch)
+        i += 1
+    if buf:
+        seg = ''.join(buf)
+        for pat, repl in REPLACEMENTS_CI:
+            seg = pat.sub(repl, seg)
+        out.append(seg)
+    return ''.join(out), depth
 
 def process_ftl_files(locale_dir: Path):
     if not locale_dir.exists():
@@ -32,6 +52,7 @@ def process_ftl_files(locale_dir: Path):
         content = file_path.read_text(encoding="utf-8")
         lines_out = []
         in_value = False
+        ph_depth = 0
 
         for line in content.splitlines(keepends=True):
             stripped = line.lstrip()
@@ -39,7 +60,7 @@ def process_ftl_files(locale_dir: Path):
 
             if "=" in line and not is_comment and not line.startswith((" ", "\t")):
                 left, right = line.split("=", 1)
-                right = replace_outside_placeholders(right)
+                right, ph_depth = replace_outside_placeholders(right, 0)
                 lines_out.append(left + "=" + right)
                 in_value = True
                 continue
@@ -47,16 +68,18 @@ def process_ftl_files(locale_dir: Path):
             if in_value and not is_comment:
                 if ATTR_RE.match(line):
                     l2, r2 = line.split("=", 1)
-                    r2 = replace_outside_placeholders(r2)
+                    r2, _ = replace_outside_placeholders(r2, 0)
                     lines_out.append(l2 + "=" + r2)
                     continue
                 if line.startswith((" ", "\t")):
-                    lines_out.append(replace_outside_placeholders(line))
+                    seg, ph_depth = replace_outside_placeholders(line, ph_depth)
+                    lines_out.append(seg)
                     continue
 
             lines_out.append(line)
-            if not line.startswith((" ", "\t")):
+            if is_comment or not line.startswith((" ", "\t")) or stripped == "":
                 in_value = False
+                ph_depth = 0
 
         new_content = "".join(lines_out)
         if new_content != content:

--- a/Tools/_lust/replace_nt.py
+++ b/Tools/_lust/replace_nt.py
@@ -7,6 +7,8 @@ REPLACEMENTS = {
     r"\bNT\b": "Qillu",
     r"\bНТ\b": "Qillu",
     r"\bНанотрейзен\b": "Qillu",
+    r"\bNanoTrasen\b": "Qillu",
+    r"\bНаноТрейзен\b": "Qillu",
 }
 
 def process_ftl_files(locale_dir: Path):

--- a/Tools/_lust/replace_nt.py
+++ b/Tools/_lust/replace_nt.py
@@ -4,21 +4,22 @@ from pathlib import Path
 
 REPLACEMENTS = {
     r"\bNanotrasen\b": "Qillu",
+    r"\bNanoTrasen\b": "Qillu",
     r"\bNT\b": "Qillu",
     r"\bНТ\b": "Qillu",
     r"\bНанотрейзен\b": "Qillu",
-    r"\bNanoTrasen\b": "Qillu",
 }
 
 PLACEHOLDER_SPLIT = re.compile(r'(\{[^{}]*\})')
+ATTR_RE = re.compile(r'^\s*\.[-\w]+\s*=')
 
 def replace_outside_placeholders(text: str) -> str:
     parts = PLACEHOLDER_SPLIT.split(text)
     for i, seg in enumerate(parts):
         if seg.startswith('{') and seg.endswith('}'):
             continue
-        for pattern, replacement in REPLACEMENTS.items():
-            seg = re.sub(pattern, replacement, seg, flags=re.IGNORECASE)
+        for pat, repl in REPLACEMENTS.items():
+            seg = re.sub(pat, repl, seg, flags=re.IGNORECASE)
         parts[i] = seg
     return ''.join(parts)
 
@@ -29,26 +30,47 @@ def process_ftl_files(locale_dir: Path):
 
     for file_path in locale_dir.rglob("*.ftl"):
         content = file_path.read_text(encoding="utf-8")
-        lines = []
-        for line in content.splitlines(True):
-            if "=" in line and not line.lstrip().startswith("#"):
+        lines_out = []
+        in_value = False
+
+        for line in content.splitlines(keepends=True):
+            stripped = line.lstrip()
+            is_comment = stripped.startswith("#")
+
+            if "=" in line and not is_comment and not line.startswith((" ", "\t")):
                 left, right = line.split("=", 1)
                 right = replace_outside_placeholders(right)
-                line = left + "=" + right
-            lines.append(line)
-        content = "".join(lines)
-        file_path.write_text(content, encoding="utf-8")
+                lines_out.append(left + "=" + right)
+                in_value = True
+                continue
+
+            if in_value and not is_comment:
+                if ATTR_RE.match(line):
+                    l2, r2 = line.split("=", 1)
+                    r2 = replace_outside_placeholders(r2)
+                    lines_out.append(l2 + "=" + r2)
+                    continue
+                if line.startswith((" ", "\t")):
+                    lines_out.append(replace_outside_placeholders(line))
+                    continue
+
+            lines_out.append(line)
+            if not line.startswith((" ", "\t")):
+                in_value = False
+
+        new_content = "".join(lines_out)
+        if new_content != content:
+            file_path.write_text(new_content, encoding="utf-8")
+
     print(f"Обработка завершена для {locale_dir}")
 
 if __name__ == "__main__":
     if "--path" in sys.argv:
-        path_index = sys.argv.index("--path") + 1
-        if path_index >= len(sys.argv):
+        idx = sys.argv.index("--path") + 1
+        if idx >= len(sys.argv):
             print("Ошибка: не указан путь после --path")
             sys.exit(2)
-        locale_dir = Path(sys.argv[path_index]).resolve()
+        process_ftl_files(Path(sys.argv[idx]).resolve())
     else:
         print("Ошибка: аргумент --path не указан")
         sys.exit(2)
-
-    process_ftl_files(locale_dir)


### PR DESCRIPTION
## Кратное описание
Существовали имена с большой буквой Т, из-за чего автозамена НТ на Qillu иногда не работала.
И были прочие проблемы 
Пример: Флаг NanoTrasen (а работало только с Nanotrasen)


<img width="483" height="188" alt="image" src="https://github.com/user-attachments/assets/7607a0eb-b1ca-47d4-a0b2-0a4438c8485f" />
<img width="393" height="190" alt="image" src="https://github.com/user-attachments/assets/168b6403-ad08-4944-9a5e-92b7b95f25f5" />


**Changelog**


:cl: daniil7383
- fix: Доработка локализации НТ на Qillu



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Новые возможности
  - Добавлена учётная, нечувствительная к регистру замена для варианта «NanoTrasen».

- Исправления ошибок
  - Замены затрагивают только значения (не ключи и комментарии).
  - Текст внутри плейсхолдеров в фигурных скобках больше не меняется.
  - Замены выполняются без учёта регистра для большей консистентности.

- Рефакторинг
  - Переработана построчная обработка файлов локализации: корректная обработка строк-значений и строк-продолжений, запись только при изменениях.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->