### PR TITLE
Mask fixes

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
@@ -127,7 +127,7 @@ public sealed class MaskSystem : EntitySystem
         // Add an easier way to get the entity that is wearing clothing in a valid slot.
         EntityUid? wearer = null;
         if (TryComp(mask, out ClothingComponent? clothing)
-            && clothing.InSlotFlag is { } slotFlag
+            && clothing.InSlotFlag is {} slotFlag
             && clothing.Slots.HasFlag(slotFlag))
         {
             wearer = Transform(mask).ParentUid;


### PR DESCRIPTION
## Кратное описание
Исправление бага с невидимой маской

## По какой причине
https://github.com/space-sunrise/lust-station/issues/241

## Медиа
Баг:

https://github.com/user-attachments/assets/ef403467-2443-42f1-9cfc-141f74ca0e81

Исправленное состояние:

https://github.com/user-attachments/assets/cda73d0d-0973-4477-947c-cafed5133bc7






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - Нет изменений, влияющих на функциональность.

- Исправления ошибок
  - Устранены случаи, когда маска после снятия оставалась в активном состоянии.
  - Обеспечена корректная деактивация всех связанных эффектов при снятии маски.
  - Синхронизированы визуальные индикаторы и действия (иконки, состояния), чтобы избежать «залипания» и рассинхрона.
  - Повышена надёжность обработки событий при смене экипировки масок, что делает поведение более предсказуемым для игроков.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->