### PR TITLE
NTR officer sheath belt add

### DIFF
--- a/Resources/Prototypes/_Sunrise/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/role_loadouts.yml
@@ -32,7 +32,7 @@
   groups:
   - BackNTR
   - UniformNTR
-  - SecurityBelt
+  - SecurityBelt # Lust Station Add
   - Trinkets
   - SecurityTrinkets
   - GroupSpeciesBreathTool

--- a/Resources/Prototypes/_Sunrise/Roles/Jobs/Law/NtrOfficer.yml
+++ b/Resources/Prototypes/_Sunrise/Roles/Jobs/Law/NtrOfficer.yml
@@ -50,6 +50,7 @@
     shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadCapNTGR
     eyes: ClothingEyesGlassesSecurity
+    #belt: ClothingBeltSecurityFilled - Lust station Edit
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterArmorNTRGLead
     id: NtrGuardPDA


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Теперь у ИСН офицеров есть выбор между поясом, рпс и ножнами в лодаутах

## По какой причине
Предложение на ДС сервере:
https://discord.com/channels/1253315855731916821/1429566632174293123

**Changelog**
:cl: Hero_010
- add: Добавлен лодаут пояса для офицеров ИСН.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Балансировка**
  * Обновлена выдача экипировки для роли NtrOfficer: добавлена группа с ремнями безопасности, при старте убраны заполненный ремень и энергетический револьвер; в конфигурации оставлена закомментированная пометка о ремне для возможного восстановления.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->