### PR TITLE
Фикс скрипта локализации

### DIFF
--- a/Tools/_lust/replace_nt.py
+++ b/Tools/_lust/replace_nt.py
@@ -58,7 +58,7 @@ def process_ftl_files(locale_dir: Path):
             stripped = line.lstrip()
             is_comment = stripped.startswith("#")
 
-            if "=" in line and not is_comment and not line.startswith((" ", "\t")):
+            if "=" in line and not is_comment and not line.startswith((" ", "\t")) and not line.lstrip().startswith("["):
                 left, right = line.split("=", 1)
                 right, ph_depth = replace_outside_placeholders(right, 0)
                 lines_out.append(left + "=" + right)
@@ -71,7 +71,7 @@ def process_ftl_files(locale_dir: Path):
                     r2, _ = replace_outside_placeholders(r2, 0)
                     lines_out.append(l2 + "=" + r2)
                     continue
-                if line.startswith((" ", "\t")):
+                if line and line[:1].isspace():
                     seg, ph_depth = replace_outside_placeholders(line, ph_depth)
                     lines_out.append(seg)
                     continue


### PR DESCRIPTION

## Кратное описание

Исправлен скрипт локализации. Не локализировало в документах цели и в таких зона "[head=1]NanoTrasen[/head]"

Причиной стал данный символ "["

Проверил скрипт - локализирует!

**Changelog**
:cl: Orvex07
- fix: Локализация документов с NT на Qillu



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Улучшена обработка строк с определением переменных: добавлена защита от неправильной интерпретации строк, начинающихся со скобок.
* Оптимизирована проверка отступов: исправлена обработка пустых строк и повышена надежность определения пробельных символов.
* Исправлены случаи ошибочной обработки краевых случаев при анализе текста.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->