### PR TITLE
passenger can't maintenance

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -6,8 +6,8 @@
   startingGear: PassengerGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone
-  access:
-  - Maintenance
+  #lust-edit access:
+  #lust-edit - Maintenance
 
 - type: startingGear
   id: PassengerGear


### PR DESCRIPTION
## Кратное описание
Пассажирам закрыт доступ в тех-помещения обслуживания

## По какой причине
Ну, они же всё таки пассажиры, а не работники станции? Для чего им техи? Только ради легального, токсичного манча. Повышаем РП логику и взаимодействие с другими отделами или ГП

**Changelog**

:cl: iDesmond
- remove: Удалены доступы пассажирам в тех-помещения

