### PR TITLE
Фикс коробки кибер-руки атмоса

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Storage/lockbox.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Storage/lockbox.yml
@@ -182,7 +182,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: LeftArmCyberHack
+    - id: LeftArmCyberAtmos
 
 - type: entity
   parent: BaseImplantCase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
Фикс коробки с рукой "Атмосианина" - в прото случилось немного копи-пасты и в ней находится рука "НетРаннер".
В репо Санрайза, между прочим, айди руки прописан корректно, но это не заапстримили.

Апдейт
Ссылка на файл из репы Санрайз: https://github.com/space-sunrise/sunrise-station/blob/master/Resources/Prototypes/_Sunrise/Entities/Objects/Storage/lockbox.yml
Строка 208.

## По какой причине
Считаю данную руку весьма полезной, а из-за этого бага её тупо невозможно сделать и только, наверное, возможно найти в техах.

## Медиа(Видео/Скриншоты)
<img width="598" height="586" alt="atmo-hand-screenshot" src="https://github.com/user-attachments/assets/17b3e3b8-a2fd-4a43-b32d-0930c35067b0" />

**Changelog**
:cl: Miolo
- fix: В коробке руки "Атмосианина" теперь находится именно эта рука, а не "НетРаннер".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Обновлено содержимое хранилища в игровом контейнере для правильного отображения требуемого предмета.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->