### PR TITLE
fix: коррекция базового пути спрайта для прототипа ERPShibariRope

### DIFF
--- a/Resources/Prototypes/_Lust/Entities/ERP/Toys/toys.yml
+++ b/Resources/Prototypes/_Lust/Entities/ERP/Toys/toys.yml
@@ -161,12 +161,12 @@
     size: Small
     storedRotation: 90
   - type: Handcuff
-    cuffedRSI: _Lust/ERP/Stuff/Shibari/shibari_gray.rsi
+    cuffedRSI: _Lust/ERP/Stuff/Shibari/shibari_white.rsi
     bodyIconState: body-overlay
     breakoutTime: 6 # Keep in mind that's a toy
     uncuffTime: 6 # /\
   - type: Sprite
-    sprite: _Lust/ERP/Stuff/Shibari/shibari_gray.rsi
+    sprite: _Lust/ERP/Stuff/Shibari/shibari_white.rsi
     state: handcuff
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Кратное описание
Заменил неактуальный путь к удалённому спрайту на новый "по-умолчанию" для всех возможных будущих прототипов-наследников `ERPShibariRope`.

## По какой причине
В прошлом PR(https://github.com/space-sunrise/lust-station/pull/471) недосмотрел, оставив путь по умолчанию к устаревшему "серому цвету" верёвки для шибари, ассет которой уже удалён и заменён новыми цветами, однако тот уже **merged**.

## Медиа(Видео/Скриншоты)
Не требуется.

<!--🆑 APA64IK
**Changelog**
- fix: Исправлен базовый путь спрайта для ERPShibariRope наследников.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai 

## Summary by CodeRabbit

## Обновление визуальных элементов

* **Визуальные улучшения**
  * Обновлена текстура аксессуара сибари — изменен цвет с серого на белый для лучшего визуального контраста и внешнего вида предмета в игре.

 end of auto-generated comment: release notes by coderabbit.ai -->