### PR TITLE
Fix-дополнения кражи плащей глав, возвращения спонсорского капитанского плаща обратно

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -169,6 +169,7 @@
   - CaptainCloak
   - CaptainCloakFormal
   - CaptainMantle
+  - CaptainSpecialCloak # Lust Station
   # Sunrise - Start
   - CaptainEliteCloak
   - CaptainScarf

--- a/Resources/Prototypes/_Lust/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Lust/Entities/Clothing/Neck/cloaks.yml
@@ -26,7 +26,7 @@
     sprite: _Lust/Clothing/Neck/Cloaks/qillu_cloak.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckCloakCap
   id: ClothingNeckCapSpecialCloak
   name: special captain cloak
   description: Special cloak for special Captain. Looks so rich.
@@ -35,7 +35,7 @@
     sprite: _Lust/Clothing/Neck/Cloaks/cap_special_cloak.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingCloakCmo
   id: ClothingNeckCmoSpecialCloak
   name: special CMO cloak
   description: Special cloak for special CMO. Looks so rich.
@@ -44,7 +44,7 @@
     sprite: _Lust/Clothing/Neck/Cloaks/cmo_special_cloak.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckCloakHop
   id: ClothingNeckHopSpecialCloak
   name: special HOP cloak
   description: Special cloak for special HOP. Looks so rich.
@@ -53,7 +53,7 @@
     sprite: _Lust/Clothing/Neck/Cloaks/hop_special_cloak.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckCloakHos
   id: ClothingNeckHosSpecialCloak
   name: special HOS cloak
   description: Special cloak for special HOS. Looks so rich.
@@ -62,7 +62,7 @@
     sprite: _Lust/Clothing/Neck/Cloaks/hos_special_cloak.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckCloakQm
   id: ClothingNeckQmSpecialCloak
   name: special QM cloak
   description: Special cloak for special QM. Looks so rich.
@@ -71,7 +71,7 @@
     sprite: _Lust/Clothing/Neck/Cloaks/qm_special_cloak.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingNeckCloakRd
   id: ClothingNeckRdSpecialCloak
   name: special RD cloak
   description: Special cloak for special RD. Looks so rich.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Добавлены еще список плащей на кражу для вора спонсорских на билде Ласта
Также возвращен плащ "Особый капитанский плащ" в лодаут капитана по подписке от гаммы
## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
Дополнения к фиксу с билда санрайза (https://github.com/space-sunrise/sunrise-station/pull/3907)
Ну исправления плащ капитана, кто-то задел лодаут этого плаща
## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="392" height="243" alt="image" src="https://github.com/user-attachments/assets/62800d44-f9b1-4932-a2b7-c6f4b485c36b" /> 
<img width="530" height="537" alt="image" src="https://github.com/user-attachments/assets/fa3c7585-6c61-4c3f-b593-69a3ca51e28f" />

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
:cl: BDSM_
- fix: Возвращен спонсорский плащ капитана в лодаут

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Добавлена новая опция специального плаща для комплекта капитана

* **Chores**
  * Обновлены свойства наследования специальных плащей для различных должностных лиц

<!-- end of auto-generated comment: release notes by coderabbit.ai -->