### PR TITLE
Проверка поля зрения для эмоутов панельки

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -942,6 +942,15 @@ public sealed partial class ChatSystem : SharedChatSystem
             var entRange = MessageRangeCheck(session, data, range);
             if (entRange == MessageRangeCheckResult.Disallowed)
                 continue;
+            // Lust-start
+            // Проверка на наличие видимости для эмоутов
+            if (
+                channel == ChatChannel.Emotes
+                && session.AttachedEntity is not null
+                && !_examineSystem.InRangeUnOccluded(source, session.AttachedEntity.Value, VoiceRange)
+            )
+                continue;
+            // Lust-end
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
             _chatManager.ChatMessageToOne(channel, message, wrappedMessage, source, entHideChat, session.Channel, author: author, colorOverride: color);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
#358 - сделать так, чтобы не было видно эмоутов панельки если они вне поля зрения.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
- ебучий спам в чат когда находишься в дормах
- нереалистично
- мета

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
Если попросите - сделаю видик, а так тут всё понятно я думаю

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделанных в данном PR, укажите их используя шаблон вне комментария.
Кратко и информативно.
-->

:cl: Miolo
- fix: Эмоции из ERP панели за препятствиями теперь не будут видны в чате.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Сообщения с эмодзи теперь доставляются только получателям, которые находятся в прямой видимости отправителя в пределах диапазона голоса.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->