### PR TITLE
FIX: Correct borg head slot offset for hats

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/borg.yml
+++ b/Resources/Prototypes/InventoryTemplates/borg.yml
@@ -47,7 +47,7 @@
     uiWindowPos: 1,0
     strippingWindowPos: 0,0
     displayName: Head
-    offset: 0.015625, 0
+    offset: 0.015625, -0.07 #Lust Edit
   # Sunrise-Edit
   - name: armor
     slotTexture: outerclothing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Изменение offset для шапок боргам.

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->
<img width="500" height="309" alt="image" src="https://github.com/user-attachments/assets/f94c0001-afa9-4202-8eb0-f53da39bdaf7" />


**Changelog**
:cl: matavsn
- fix: Отображение шапок на боргах.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Исправления ошибок**

* Отрегулирована позиция экипировки персонажа для улучшения визуального отображения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->