### PR TITLE
Adding a material bag to the suitStorage slot

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Engineering/material_bag.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Engineering/material_bag.yml
@@ -13,6 +13,7 @@
     quickEquip: false
     slots:
     - belt
+    - suitStorage
   - type: Item
     size: Ginormous
   - type: Storage
@@ -38,3 +39,4 @@
         - Board
         - StationMapElectronics
   - type: Dumpable
+


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Добавлена возможность носить инженерную сумку в слоте спины скафандра, но без автосбора материалов в неё.
<!--
[RU] Что вы предлагаете изменить с помощью своего PR?
[EN] What does this PR propose to change?
-->

## Ссылка на багрепорт/Предложение | Related Issue/Bug Report
<!--
[RU] Ссылки на Дискуссии и Баг-репорты указывать здесь.
[EN] Provide links to Discussions or Bug Reports here.
-->

## Медиа (Видео/Скриншоты) | Media (Video/Screenshots)
<!--
[RU] Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
[EN] If your PR contains in-game changes, you must provide screenshots/video of the changes.
-->


**Инженерную сумку для материалов теперь можно носить в слоте спины скафандра, однако в таком положении она не будет засасывать в себя ресурсы.**

:cl: Nordstream17
- tweak: Добавлена возможность носить сумку для материалов в слоте спины скафандра.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Расширена функциональность сумки с материалами, добавлена поддержка хранения предметов.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/space-sunrise/lust-station/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->