### PR TITLE
Cutting wires with knives and swords

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -79,8 +79,11 @@
     butcherDelayModifier: 1.5 # Butchering with a scalpel, regardless of the type, will take 50% longer
   - type: Tool
     qualities:
-    - Slicing
-    speedModifier: 0.66 # pretend the sixes go on forever :)
+      - Cutting
+      - Slicing
+    speedModifier: 0.6
+    useSound:
+      path: /Audio/Items/wirecutter.ogg
   - type: Utensil
     types:
       - Knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -24,9 +24,11 @@
     size: Small
   - type: Tool
     qualities:
+      - Cutting
       - Slicing
+    speedModifier: 0.6
     useSound:
-      path: /Audio/Items/Culinary/chop.ogg
+      path: /Audio/Items/wirecutter.ogg
   # Sunrise-start
   - type: Scalpel
   - type: SurgeryTool
@@ -404,9 +406,8 @@
       - Knife
     - type: Tool
       qualities:
-      - Slicing
-      useSound:
-        path: /Audio/Items/Culinary/chop.ogg
+        - Cutting
+        - Slicing
   - type: Item
     size: Tiny
     sprite: Objects/Weapons/Melee/utility_knife.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -20,7 +20,11 @@
       - Knife
   - type: Tool
     qualities:
-    - Slicing
+      - Cutting
+      - Slicing
+    speedModifier: 0.6
+    useSound:
+      path: /Audio/Items/wirecutter.ogg
 
 #Shortswords
 - type: entity


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Добавлена возможность перерезать провода с помощью ножей, мечей и кинжалов(только те виды оружия, которые до этого могли использоваться для нарезки)<!--
[RU] Что вы предлагаете изменить с помощью своего PR?
[EN] What does this PR propose to change?
-->

## Ссылка на багрепорт/Предложение | Related Issue/Bug Report
<!--
[RU] Ссылки на Дискуссии и Баг-репорты указывать здесь.
[EN] Provide links to Discussions or Bug Reports here.
-->

## Медиа (Видео/Скриншоты) | Media (Video/Screenshots)
<!--
[RU] Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
[EN] If your PR contains in-game changes, you must provide screenshots/video of the changes.
-->




:cl: Nordstream17
- add:Возможность перерезать провода ножами и мечами


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Балансировка игровых механик**
  * Обновлены характеристики режущих инструментов и оружия: добавлено качество "Cutting" для скальпеля, ножей и мечей.
  * Настроены звуковые эффекты для инструментов и оружия.
  * Отрегулированы показатели скорости для улучшения игровой механики.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/space-sunrise/lust-station/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->