### PR TITLE
[FIX] Отображение клеток на корректном слое у рас.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -94,19 +94,24 @@
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
       - map: ["enum.HumanoidVisualLayers.LFoot"]
       - map: ["enum.HumanoidVisualLayers.RFoot"]
+      - map: [ "lockable_under" ] # Lust-Edit
+      - map: [ "lockable_chest" ] # Lust-Edit
       # Sunrise-start
       - map: ["bra"]
       - map: ["pants"]
       - map: ["socks"]
       - map: ["plug"]
+      - map: ["lockable_underpants"] # Lust-Edit
       - map: ["jumpsuit"]
       # Sunrise-end
       - map: ["enum.HumanoidVisualLayers.LHand"]
       - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "gloves" ]
       - map: [ "shoes" ]
+      - map: [ "lockable_normal" ] # Lust-Edit
       - map: [ "belt" ]
       - map: [ "id" ]
+      - map: [ "lockable_over" ] # Lust-Edit
       - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
       - map: [ "back" ]
       - map: [ "neck" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -109,9 +109,9 @@
       - map: [ "gloves" ]
       - map: [ "shoes" ]
       - map: [ "lockable_normal" ] # Lust-Edit
+      - map: [ "lockable_over" ] # Lust-Edit
       - map: [ "belt" ]
       - map: [ "id" ]
-      - map: [ "lockable_over" ] # Lust-Edit
       - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
       - map: [ "back" ]
       - map: [ "neck" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -99,11 +99,14 @@
       - map: [ "enum.HumanoidVisualLayers.RHand" ]
       - map: [ "enum.HumanoidVisualLayers.LFoot" ]
       - map: [ "enum.HumanoidVisualLayers.RFoot" ]
+      - map: [ "lockable_under" ] # Lust-Edit
+      - map: [ "lockable_chest" ] # Lust-Edit
       # Sunrise-start
       - map: ["bra"]
       - map: ["pants"]
       - map: ["socks"]
       - map: ["plug"]
+      - map: ["lockable_underpants"] # Lust-Edit
       - map: ["jumpsuit"]
       # Sunrise-end
       - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
@@ -114,7 +117,9 @@
       - map: [ "gloves" ]
       - map: [ "shoes" ]
       - map: [ "ears" ]
+      - map: [ "lockable_normal" ] # Lust-Edit
       - map: [ "outerClothing" ] #Sunrise-edit
+      - map: [ "lockable_over" ] # Lust-Edit
       - map: [ "eyes" ]
       - map: [ "belt" ]
       - map: [ "id" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -121,15 +121,20 @@
     - map: [ "enum.HumanoidVisualLayers.LLeg" ]
     - map: [ "enum.HumanoidVisualLayers.LFoot" ]
     - map: [ "enum.HumanoidVisualLayers.RFoot" ]
+    - map: [ "lockable_under" ] # Lust-Edit
+    - map: [ "lockable_chest" ] # Lust-Edit
     - map: [ "enum.HumanoidVisualLayers.LHand" ]
     - map: [ "enum.HumanoidVisualLayers.RHand" ]
     # Sunrise-start
+    - map: [ "lockable_underpants" ] # Lust-Edit
     - map: ["jumpsuit"]
     # Sunrise-end
     - map: [ "gloves" ]
     - map: [ "shoes" ]
     - map: [ "ears" ]
+    - map: [ "lockable_normal" ] # Lust-Edit
     - map: [ "outerClothing" ] #Sunrise-edit
+    - map: [ "lockable_over" ] # Lust-Edit
     - map: [ "eyes" ]
     - map: [ "belt" ]
     - map: [ "id" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -87,16 +87,21 @@
     - map: [ "enum.HumanoidVisualLayers.LLeg" ]
     - map: ["enum.HumanoidVisualLayers.LFoot"]
     - map: ["enum.HumanoidVisualLayers.RFoot"]
+    - map: ["lockable_under"] # Lust-Edit
+    - map: ["lockable_chest"] # Lust-Edit
     - map: ["bra"]
     - map: ["pants"]
     - map: ["socks"]
+    - map: ["lockable_underpants"] # Lust-Edit
     - map: ["jumpsuit"]
     - map: ["enum.HumanoidVisualLayers.LHand"]
     - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: [ "gloves" ]
     - map: [ "shoes" ]
     - map: [ "ears" ]
+    - map: [ "lockable_normal" ] # Lust-Edit
     - map: [ "outerClothing" ]
+    - map: [ "lockable_over" ] # Lust-Edit
     - map: [ "eyes" ]
     - map: [ "belt" ]
     - map: [ "id" ]


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
Забыл добавить маппинг лэеров в прототипах рас, которые переопределяют маппинг, из-за чего на определенных расах клетки отображались поверх одежды



## Медиа (Видео/Скриншоты) | Media (Video/Screenshots)
-

**Changelog**

:cl: MataVsn
- fix: Корректно отображение клеток на расах.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Изменения

* **Chores**
  * Обновлены визуальные слои отображения для четырёх видов персонажей (арахнид, мотылёк, вокс, вулпканин): добавлены новые «lockable» слои и скорректирован порядок слоёв для улучшенного и корректного наложения одежды и экипировки.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->